### PR TITLE
Delete string access in IdentityMorphism

### DIFF
--- a/gap/Bialgebroids.gi
+++ b/gap/Bialgebroids.gi
@@ -340,13 +340,15 @@ InstallGlobalFunction( ADD_FUNCTIONS_FOR_ALGEBROID,
     ##
     AddIdentityMorphism( category,
       function( object )
-        local A;
+        local quiver_algebra, id;
         
-        A := UnderlyingQuiverAlgebra( CapCategory( object ) );
+        quiver_algebra := UnderlyingQuiverAlgebra( CapCategory( object ) );
+        
+        id := PathAsAlgebraElement( quiver_algebra, UnderlyingVertex( object ) );
         
         return MorphismInAlgebroid(
                        object,
-                       A.(String( UnderlyingVertex( object ) ) ),
+                       id,
                        object );
         
     end );


### PR DESCRIPTION
for bialgebroids. 

This PR is a contribution to the idea that one should try to use an unambiguous interface for accessing the quiver algebra elements.