### PR TITLE
Delete Basering from bialgebroids

### DIFF
--- a/examples/doc/Algebroid.g
+++ b/examples/doc/Algebroid.g
@@ -44,7 +44,7 @@ SetOfObjects( Ar );
 #! [ (u), (v), (w) ]
 SetOfGeneratingMorphisms( Ar );
 #! [ (u)-[1*(a)]->(v), (v)-[1*(b)]->(u), (v)-[1*(c)]->(u), (v)-[1*(d)]->(w) ]
-BaseRing(Al) = Q;
+CommutativeRingOfLinearCategory(Al) = Q;
 #! true
 ObjectInAlgebroid(Al, ql.u) = Al.u;
 #! true

--- a/gap/Bialgebroids.gd
+++ b/gap/Bialgebroids.gd
@@ -119,13 +119,6 @@ DeclareAttribute( "UnderlyingQuiverAlgebra",
         IsAlgebroid );
 
 #! @Description
-#!  The base ring of the algebroid <A>A</A>.
-#! @Arguments A
-#! @Returns a ring
-DeclareAttribute( "BaseRing",
-        IsAlgebroid );
-
-#! @Description
 #!  The finite set of objects of the finitely presented algebroid <A>A</A>.
 #! @Arguments A
 #! @Returns a list

--- a/gap/Bialgebroids.gi
+++ b/gap/Bialgebroids.gi
@@ -687,17 +687,6 @@ InstallMethod( Algebroid,
     
 end );
 
-InstallMethod( BaseRing,
-        "for an algebroid",
-        [ IsAlgebroid ],
-
-  function( A )
-
-    return LeftActingDomain( UnderlyingQuiverAlgebra( A ) );
-
-end );
-
-
 
 ##
 InstallMethod( Multiplication,


### PR DESCRIPTION
I suggest to delete `BaseRing` from algebroids, since it is now covered by the concept of a `CommutativeRingOfLinearCategory`. If you think this is reasonable, then I'll open this Draft-PR for merging.