### PR TITLE
Improve tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,6 +17,7 @@ jobs:
           git clone --depth 1 https://github.com/oysteins/InfiniteLists.git
           git clone --depth 1 https://github.com/kamalsaleh/ComplexesForCAP.git
           git clone --depth 1 https://github.com/oysteins/QPA2.git
+          git clone --depth 1 https://github.com/gap-packages/AutoDoc.git
           cd Bialgebroids
           echo "SetUserPreference(\"PackagesToLoad\", []);" > ~/.gap/gap.ini
           echo "SetInfoLevel(InfoPackageLoading, 3);" > ~/.gap/gaprc

--- a/makedoc.g
+++ b/makedoc.g
@@ -23,6 +23,7 @@ AutoDoc(
                                "LoadPackage( \"GaussForHomalg\" );",
                              ],
                            ),
+            extract_examples := true,
             )
 );
 

--- a/makefile
+++ b/makefile
@@ -12,13 +12,14 @@ clean:
 	(cd doc ; ./clean)
 
 test:	doc
-	gap maketest.g
+	gap tst/testall.g
 
 test-tabs:
 	! grep -RP "\t" examples/ gap/
 
 test-with-coverage: doc
-	gap --cover stats maketest.g | perl -pe 'END { exit $$status } $$status=1 if /Expected output/;'
+	#gap --cover stats maketest.g | perl -pe 'END { exit $$status } $$status=1 if /Expected output/;'
+	gap --cover stats tst/testall.g
 	echo 'LoadPackage("profiling"); OutputJsonCoverage("stats", "coverage.json");' | gap
 
 test-spacing:

--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ test:	doc
 	gap tst/testall.g
 
 test-tabs:
-	! grep -RP "\t" examples/ gap/
+	! grep -RP "\t" examples/*.g gap/*.gi gap/*.gd
 
 test-with-coverage: doc
 	#gap --cover stats maketest.g | perl -pe 'END { exit $$status } $$status=1 if /Expected output/;'

--- a/makefile
+++ b/makefile
@@ -15,7 +15,7 @@ test:	doc
 	gap tst/testall.g
 
 test-tabs:
-	! grep -RP "\t" examples/*.g gap/*.gi gap/*.gd
+	! grep -RP "\t" examples/*.g examples/doc/*.g gap/*.gi gap/*.gd
 
 test-with-coverage: doc
 	#gap --cover stats maketest.g | perl -pe 'END { exit $$status } $$status=1 if /Expected output/;'

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -7,6 +7,7 @@
 LoadPackage( "Bialgebroids" );
 
 LoadPackage( "GaussForHomalg" );
+HOMALG_IO.show_banners := false;
 TestDirectory(DirectoriesPackageLibrary( "Bialgebroids", "tst" ),
   rec(exitGAP := true));
 

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -6,6 +6,7 @@
 #
 LoadPackage( "Bialgebroids" );
 
+LoadPackage( "GaussForHomalg" );
 TestDirectory(DirectoriesPackageLibrary( "Bialgebroids", "tst" ),
   rec(exitGAP := true));
 

--- a/tst/testall.g
+++ b/tst/testall.g
@@ -7,8 +7,14 @@
 LoadPackage( "Bialgebroids" );
 
 LoadPackage( "GaussForHomalg" );
+
 HOMALG_IO.show_banners := false;
-TestDirectory(DirectoriesPackageLibrary( "Bialgebroids", "tst" ),
-  rec(exitGAP := true));
+
+TestDirectory( DirectoriesPackageLibrary( "Bialgebroids", "tst" ),
+  rec(
+        testOptions := rec ( compareFunction := "uptowhitespace" ),
+        exitGAP := true,
+     )
+);
 
 FORCE_QUIT_GAP(1); # if we ever get here, there was an error


### PR DESCRIPTION
The `makefile` refered to `maketest.g`, which does not exist. This PR changes `makefile` in order to use `tst/testall.g` and introduces necessary changes in the latter.

Moreover I restricted the tab tests to relevant files (examples/*.g gap/*.gi gap/*.gd).